### PR TITLE
Speed! Upload in parallel

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -230,13 +230,14 @@ def main(argv=None):  # IGNORE:C0111
             parser.add_argument('-d', '--dryrun', action='store_true', help="Show what would be uploaded but don't upload it.")
             parser.add_argument('-f', '--force', action='store_true', help="Force uploads, else only upload if changed.")
             parser.add_argument('-s', '--scheduled', action='store_true', help="Upload only when the configured schedule allows.")
+            parser.add_argument('-n','--num_threads', nargs='?', const=1, type=int,help="Number of parallel uploads while uploading a directory")
             parser.add_argument('local', help='The file/folder/path to put')
             parser.add_argument('remote', nargs='?', help='The remote folder to put it in')
             args = parser.parse_args()
             if args.config:
                 degoo.api.report_config()
 
-            result = degoo.put(args.local, args.remote, args.verbose, not args.force, args.dryrun, args.scheduled)
+            result = degoo.put(args.local, args.remote, args.verbose, not args.force, args.dryrun, args.scheduled,args.num_threads)
 
             if not args.dryrun:
                 if len(result) == 3:

--- a/degoo/util.py
+++ b/degoo/util.py
@@ -1166,7 +1166,7 @@ def put_file(local_file, remote_folder, verbose=0, if_changed=False, dry_run=Fal
         return (ID, Path, URL)
 
 
-def put_directory(local_directory, remote_folder, verbose=0, if_changed=False, dry_run=False, schedule=False):
+def put_directory(local_directory, remote_folder, verbose=0, if_changed=False, dry_run=False, schedule=False,num_threads=1):
     '''
     Uploads a local directory recursively to the Degoo cloud store.
 
@@ -1185,8 +1185,8 @@ def put_directory(local_directory, remote_folder, verbose=0, if_changed=False, d
     logging.basicConfig(format=format, level=logging.INFO,
 
                         datefmt="%H:%M:%S")
-    num_workers = 10
-    q = start_queue(num_workers)
+    
+    q = start_queue(num_threads)
 
     target_dir = get_dir(remote_folder)
     (target_junk, target_name) = os.path.split(local_directory)
@@ -1212,7 +1212,7 @@ def put_directory(local_directory, remote_folder, verbose=0, if_changed=False, d
 
         for name in files:
             Name = os.path.join(root, name)
-            if num_workers == 1: ## Enable or disable Progressbar 
+            if num_threads == 1: ## Enable or disable Progressbar 
                 q.put([Name, IDs[root], verbose, if_changed, dry_run, schedule,True])
             else:
                 q.put([Name, IDs[root], verbose, if_changed, dry_run, schedule,False])
@@ -1222,7 +1222,7 @@ def put_directory(local_directory, remote_folder, verbose=0, if_changed=False, d
     return (IDs[Root], target_dir["Path"])
 
 
-def put(local_path, remote_folder, verbose=0, if_changed=False, dry_run=False, schedule=False):
+def put(local_path, remote_folder, verbose=0, if_changed=False, dry_run=False, schedule=False,num_threads=1):
     '''
     Uplads a file or folder to the Degoo cloud store
 
@@ -1236,7 +1236,7 @@ def put(local_path, remote_folder, verbose=0, if_changed=False, dry_run=False, s
     isDirectory = os.path.isdir(local_path)
 
     if isDirectory:
-        return put_directory(local_path, remote_folder, verbose, if_changed, dry_run, schedule)
+        return put_directory(local_path, remote_folder, verbose, if_changed, dry_run, schedule,num_threads)
     elif isFile:
         return put_file(local_path, remote_folder, verbose, if_changed, dry_run, schedule)
     else:

--- a/degoo/util.py
+++ b/degoo/util.py
@@ -924,7 +924,7 @@ def worker_func(q, thread_no):
         task = q.get()
         for i in range(3):        
             try:
-                put_file(task[0],task[1],task[2],task[3],task[4],task[5],skip_step4=True)
+                put_file(task[0],task[1],task[2],task[3],task[4],task[5])
                 
                 break
             except Exception as e:
@@ -933,7 +933,6 @@ def worker_func(q, thread_no):
                     logging.error(e)
                     break
                 continue 
-        os.remove(task[0])
         q.task_done()
         print(f'Thread #{thread_no} is done uploading {os.path.basename(task[0])}. #{q.qsize()} tasks left ')
     
@@ -1210,7 +1209,7 @@ def put_directory(local_directory, remote_folder, verbose=0, if_changed=False, d
 
         for name in files:
             Name = os.path.join(root, name)
-            q.put(Name, IDs[root], verbose, if_changed, dry_run, schedule)
+            q.put([Name, IDs[root], verbose, if_changed, dry_run, schedule])
 
     # Directories have no download URL, they exist only as Degoo metadata
     q.join()

--- a/degoo/util.py
+++ b/degoo/util.py
@@ -1003,7 +1003,8 @@ def put_file(local_file, remote_folder, verbose=0, if_changed=False, dry_run=Fal
             # Odd, to say the least.
             Type = os.path.splitext(local_file)[1][1:]
             Checksum = api.check_sum(local_file)
-
+            Checksum = Checksum.replace("/","_")
+            Checksum = Checksum.replace("+","-")
             if Type:
                 Key = "{}{}/{}.{}".format(KeyPrefix, Type, Checksum, Type)
             else:


### PR DESCRIPTION
When a folder is uploaded in the browser, the browser uses several parallel processes. 
We can do that too.

I have added an argument to the put: -n
With this, the number of parallel uploads can be chosen.
We don't have a process bar if more than one upload is running in parallel.

I have also started to use logging in rudiments. 